### PR TITLE
[refactor] Header 장바구니 탭 컴포넌트 분리 및 라우팅 개선

### DIFF
--- a/src/app/(checkout)/cart/_features/CartList.tsx
+++ b/src/app/(checkout)/cart/_features/CartList.tsx
@@ -5,6 +5,7 @@ import type { CartItem } from '@/app/api/cart/route';
 import { Button, CheckBox, NoData, QuantityController } from '@/components';
 import type { QuantityHandlerType } from '@/lib/types';
 import { ShoppingCartIcon } from 'lucide-react';
+import Link from 'next/link';
 import { memo } from 'react';
 import styles from './CartList.module.scss';
 
@@ -86,9 +87,9 @@ function Item({
         onChange={(e) => onToggle(e, item.cartItemId)}
       />
 
-      <button type="button" className={styles.item__info}>
+      <Link href={`/product/${item.productId}`} className={styles.item__info}>
         <ProductInfo item={item} type="cart" />
-      </button>
+      </Link>
 
       <div className={styles.item__quantity}>
         <QuantityController

--- a/src/app/(checkout)/cart/_features/useCart.ts
+++ b/src/app/(checkout)/cart/_features/useCart.ts
@@ -13,8 +13,6 @@ export default function useCart() {
   const { data: cartItems } = useSuspenseQuery({
     queryKey: ['cart'],
     queryFn: async () => await fetchCartItems(userId),
-    // FIXME: 임시로 캐시 무효화
-    gcTime: 0,
   });
 
   const { checkedItems, handleToggleAll, handleDeleteItem, handleToggle } =

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -26,7 +26,7 @@ type RawCartResponse = {
 
 export type CartItem = {
   cartItemId: string;
-  producId: string;
+  productId: string;
   inventoryId: string;
   title: string;
   image: string;
@@ -82,7 +82,7 @@ export async function GET(req: Request) {
   const flatItems: CartItem[] =
     cart.cart_items.map((item) => ({
       cartItemId: item.cart_item_id,
-      producId: item.product_id,
+      productId: item.product_id,
       inventoryId: item.inventory_id,
       title: item.product?.title,
       image: item.product?.image,

--- a/src/components/cart-badge/CartNavLink.tsx
+++ b/src/components/cart-badge/CartNavLink.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { CartBadge } from '@/components';
+import styles from '@/components/layouts/header/Header.module.scss';
+import Link from 'next/link';
+import useCartBadge from './useCartBadge';
+
+export default function CartNavLink() {
+  const { badgeCount } = useCartBadge();
+
+  return (
+    <Link href="/cart" className={styles.tabs__tab}>
+      CART
+      {!!badgeCount && <CartBadge quantity={badgeCount} />}
+    </Link>
+  );
+}

--- a/src/components/cart-badge/useCartBadge.ts
+++ b/src/components/cart-badge/useCartBadge.ts
@@ -1,0 +1,24 @@
+import { fetchCartItems } from '@/lib/api';
+import { userIdAtom } from '@/lib/store';
+import { useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useRouter } from 'next/navigation';
+
+export default function useCartBadge() {
+  const router = useRouter();
+  const userId = useAtomValue(userIdAtom);
+
+  const { data: cartItems } = useQuery({
+    queryKey: ['cart'],
+    queryFn: async () => await fetchCartItems(userId ?? ''),
+    enabled: !!userId,
+  });
+
+  const handleCartButton = () => {
+    router.push('/cart');
+  };
+
+  const badgeCount = cartItems?.length ?? 0;
+
+  return { badgeCount, handleCartButton, userId };
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as CheckBox } from './checkbox/CheckBox';
 export { default as CheckoutSteps } from './CheckoutSteps';
 export { default as Dropdown } from './dropdown/Dropdown';
 export { default as NoData } from './NoData';
+export { default as CartNavLink } from './cart-badge/CartNavLink';

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { CartBadge } from '@/components';
+import { CartNavLink } from '@/components';
 import useHeader from '@/components/layouts/header/useHeader';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from './Header.module.scss';
 
 export default function Header() {
-  const { badgeCount, userEmail, handleLogout, handleCartButton } = useHeader();
+  const { userEmail, handleLogout } = useHeader();
 
   return (
     <header className={styles.header}>
@@ -23,15 +23,7 @@ export default function Header() {
           </div>
         )}
 
-        <button
-          type="button"
-          className={styles.tabs__tab}
-          onClick={handleCartButton}
-          disabled={!userEmail}
-        >
-          CART
-          {!!badgeCount && <CartBadge quantity={badgeCount} />}
-        </button>
+        <CartNavLink />
 
         {userEmail && (
           <button onClick={handleLogout} type="button">

--- a/src/components/layouts/header/Header.tsx
+++ b/src/components/layouts/header/Header.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import styles from './Header.module.scss';
 
 export default function Header() {
-  const { items, userEmail, handleLogout, handleCartButton } = useHeader();
+  const { badgeCount, userEmail, handleLogout, handleCartButton } = useHeader();
 
   return (
     <header className={styles.header}>
@@ -30,7 +30,7 @@ export default function Header() {
           disabled={!userEmail}
         >
           CART
-          {!!items.length && <CartBadge quantity={items.length} />}
+          {!!badgeCount && <CartBadge quantity={badgeCount} />}
         </button>
 
         {userEmail && (

--- a/src/components/layouts/header/useHeader.ts
+++ b/src/components/layouts/header/useHeader.ts
@@ -1,20 +1,12 @@
 import { signOutUser } from '@/lib/api';
-import { fetchCartItems } from '@/lib/api';
 import { userAtom } from '@/lib/store';
-import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
 export default function useHeader() {
+  const router = useRouter();
   const [user, setUser] = useAtom(userAtom);
   const userEmail = user?.email ?? '';
-  const router = useRouter();
-  const { data: cartItems } = useQuery({
-    queryKey: ['cart'],
-    queryFn: async () => await fetchCartItems(user?.id ?? ''),
-  });
-
-  const badgeCount = cartItems?.length ?? 0;
 
   const handleLogout = async () => {
     await signOutUser();
@@ -22,14 +14,8 @@ export default function useHeader() {
     router.push('/');
   };
 
-  const handleCartButton = () => {
-    router.push('/cart');
-  };
-
   return {
-    badgeCount,
     userEmail,
     handleLogout,
-    handleCartButton,
   };
 }

--- a/src/components/layouts/header/useHeader.ts
+++ b/src/components/layouts/header/useHeader.ts
@@ -1,18 +1,24 @@
 import { signOutUser } from '@/lib/api';
-import { cartItemsAtom, userAtom } from '@/lib/store';
+import { fetchCartItems } from '@/lib/api';
+import { userAtom } from '@/lib/store';
+import { useQuery } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
 export default function useHeader() {
-  const [items, setItems] = useAtom(cartItemsAtom);
   const [user, setUser] = useAtom(userAtom);
   const userEmail = user?.email ?? '';
   const router = useRouter();
+  const { data: cartItems } = useQuery({
+    queryKey: ['cart'],
+    queryFn: async () => await fetchCartItems(user?.id ?? ''),
+  });
+
+  const badgeCount = cartItems?.length ?? 0;
 
   const handleLogout = async () => {
     await signOutUser();
     setUser(null);
-    setItems([]);
     router.push('/');
   };
 
@@ -21,7 +27,7 @@ export default function useHeader() {
   };
 
   return {
-    items,
+    badgeCount,
     userEmail,
     handleLogout,
     handleCartButton,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,9 +1,5 @@
-import type { CartItem } from '@/lib/types';
 import type { User } from '@supabase/supabase-js';
 import { atom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
-
-export const cartItemsAtom = atomWithStorage<CartItem[]>('cart', []);
 
 export const userAtom = atom<User | null>(null);
 export const userIdAtom = atom((get) => get(userAtom)?.id ?? '');


### PR DESCRIPTION
## 변경사항

1. 장바구니 배지 query 연결
   - Header 컴포넌트에서 useQuery(['cart'])를 통해 장바구니 아이템 수 표시


2. 장바구니 목록 리스트 Button -> Link 페이지 연결
   - 장바구니 상품 미리보기 목록 내 버튼을 Link로 변경
   - 클릭 시 /detail/[id] 페이지로 이동하도록 연결


3. 헤더 내 장바구니 탭 컴포넌트(CartNavLink) 모듈화
   - Header에 있던 장바구니 탭 UI를 CartNavLink 컴포넌트로 분리
   - 뱃지 수량 표시, 라우팅 등을 컴포넌트 내부 훅으로 캡슐화